### PR TITLE
Typo in dependency on MeasureIt.Core

### DIFF
--- a/src/MeasureIt.Castle.Interception/MeasureIt.Castle.Interception.nuspec
+++ b/src/MeasureIt.Castle.Interception/MeasureIt.Castle.Interception.nuspec
@@ -12,7 +12,7 @@
         <copyright>Copyright © 2016</copyright>
         <tags>MeasureIt interception measurement performance counter counters Castle Interceptor IInterceptor</tags>
         <dependencies>
-            <dependency id="MeaureIt.Core" version="1.16.0" />
+            <dependency id="MeasureIt.Core" version="1.16.0" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
The dependency resolution fails, and I cannot install the package because of this.